### PR TITLE
fix: correct release-please manifest releaser for planning component

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,8 +2,8 @@
   "separate-pull-requests": true,
   "packages": {
     "planning": {
-      "release-type": "simple"
+      "release-type": "simple",
+      "package-name": "planning"
     }
-  },
-  "plugins": ["node-workspace"]
+  }
 }


### PR DESCRIPTION
Fixes the release-please configuration to properly handle the `planning` component as a manifest releaser instead of creating whole-repo releases.

## Changes

- Removed inappropriate `node-workspace` plugin from release-please config
- Added explicit `package-name: "planning"` to ensure component-scoped releases
- This should make release-please create PRs titled like "chore(planning): release planning-v1.0.0" instead of generic whole-repo format

## Change Type

Indicate the type of changes in this pull request (required):

_Release will be generated_
- [x] `Bug Fix`
- [ ] `Enhancement`
- [ ] `Major Change`
- [ ] `Tests`
- [ ] `Miscellaneous`

_No release will be generated_
- [ ] `Build System`
- [ ] `Documentation`

_No release will be generated, even if combined with other labels_
- [ ] `Skip Release`